### PR TITLE
Avoid excluding failing tests that need addressing

### DIFF
--- a/test/TesterInternal/CodeGeneratorTests.cs
+++ b/test/TesterInternal/CodeGeneratorTests.cs
@@ -21,10 +21,7 @@ namespace UnitTests.CodeGeneration
             Assert.False(TypeUtils.IsGrainClass(t), t.FullName + " is not grain class");
             t = typeof(Orleans.Runtime.GrainDirectory.RemoteGrainDirectory);
             Assert.False(TypeUtils.IsGrainClass(t), t.FullName + " should not be a grain class");
-#if !NETSTANDARD_TODO
-           //blocked by CachedTypeResolver not coreclr compatible yet
             Assert.True(TypeUtils.IsSystemTargetClass(t), t.FullName + " should be a system target class");
-#endif
         }
 
         [Fact, TestCategory("Functional"), TestCategory("CodeGen"), TestCategory("Generics")]

--- a/test/TesterInternal/OrleansRuntime/ExceptionsTests.cs
+++ b/test/TesterInternal/OrleansRuntime/ExceptionsTests.cs
@@ -14,8 +14,7 @@ namespace UnitTests.OrleansRuntime
             BufferPool.InitGlobalBufferPool(new MessagingConfiguration(false));
             SerializationManager.Initialize(null);
         }
-#if !NETSTANDARD_TODO
-        //blocked by Exception serialization not supported in vNext yet
+
         [Fact, TestCategory("Functional"), TestCategory("Serialization")]
         public void SerializationTests_Exception_DotNet()
         {
@@ -43,6 +42,5 @@ namespace UnitTests.OrleansRuntime
             Assert.Equal(original.ActivationToUse, output.ActivationToUse);
             Assert.Equal(original.PrimaryDirectoryForGrain, output.PrimaryDirectoryForGrain);
         }
-#endif
     }
 }


### PR DESCRIPTION
We should not be using conditional compilation to exclude failing tests that need immediate addressing, as it hides what the current progress of the port is. We should only conditionally exclude if we either don't plan to address in the short term, or if the test fails to build entirely until we address the feature in the Orleans codebase.
This is so we can merge https://github.com/dotnet/orleans/pull/2245
