### PR TITLE
Silo host builder

### DIFF
--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -39,7 +39,7 @@ namespace Orleans.Storage
     ///         DeleteStateOnClear="true"
     ///       />
     ///   &lt;/StorageProviders>
-    /// </code>
+    /// </code>a
     /// </example>
     public class AzureTableStorage : IStorageProvider, IRestExceptionDecoder
     {

--- a/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
+++ b/src/OrleansAzureUtils/Providers/Storage/AzureTableStorage.cs
@@ -39,7 +39,7 @@ namespace Orleans.Storage
     ///         DeleteStateOnClear="true"
     ///       />
     ///   &lt;/StorageProviders>
-    /// </code>a
+    /// </code>
     /// </example>
     public class AzureTableStorage : IStorageProvider, IRestExceptionDecoder
     {

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -59,6 +59,8 @@
     <Compile Include="Catalog\ActivationState.cs" />
     <Compile Include="Catalog\GrainCreator.cs" />
     <Compile Include="Counters\CounterConfigData.cs" />
+    <Compile Include="Silo\ISiloHostBuilder.cs" />
+    <Compile Include="Silo\SiloHostBuilder.cs" />
     <Compile Include="Startup\ConfigureServicesBuilder.cs" />
     <Compile Include="Startup\StartupBuilder.cs" />
     <Compile Include="MultiClusterNetwork\MultiClusterData.cs" />

--- a/src/OrleansRuntime/Silo/ISiloHostBuilder.cs
+++ b/src/OrleansRuntime/Silo/ISiloHostBuilder.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Host;
+
+namespace Orleans.Runtime.Startup
+{
+    public interface ISiloHostBuilder
+    {
+        SiloHost Build(string siloName);
+        ISiloHostBuilder ConfigureLogging(System.Action<Microsoft.Extensions.Logging.ILoggerFactory> loggerFactoryDelegate);
+        ISiloHostBuilder ConfigureServices(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> configServiceDelegate);
+
+        ISiloHostBuilder UseLoggerFactory(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory);
+
+        ISiloHostBuilder UseClusterConfiguration(ClusterConfiguration clusterConfiguration);
+
+        ISiloHostBuilder UseStartup<TStartup>();
+    }
+}

--- a/src/OrleansRuntime/Silo/SiloHost.cs
+++ b/src/OrleansRuntime/Silo/SiloHost.cs
@@ -79,35 +79,50 @@ namespace Orleans.Runtime.Host
         private EventWaitHandle startupEvent;
         private EventWaitHandle shutdownEvent;
         private bool disposed;
-
+        private IServiceProvider internalServiceProvider;
+        private IServiceProvider externalServiceProvider;
+        private bool useCustomServiceProvider;
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="siloName">Name of this silo.</param>
-        public SiloHost(string siloName)
+        public SiloHost(string siloName, 
+            IServiceProvider internalServiceProvider = null, IServiceProvider externalServiceProvider = null,
+            bool useCustomServiceProvider = false)
         {
             Name = siloName;
             Type = Silo.SiloType.Secondary; // Default
             IsStarted = false;
+            this.internalServiceProvider = internalServiceProvider;
+            this.externalServiceProvider = externalServiceProvider;
         }
 
         /// <summary> Constructor </summary>
         /// <param name="siloName">Name of this silo.</param>
         /// <param name="config">Silo config that will be used to initialize this silo.</param>
-        public SiloHost(string siloName, ClusterConfiguration config) : this(siloName)
+        public SiloHost(string siloName, ClusterConfiguration config, 
+            IServiceProvider internalServiceProvider = null, IServiceProvider externalServiceProvider = null,
+            bool useCustomServiceProvider = false) : 
+            this(siloName)
         {
             SetSiloConfig(config);
+            this.internalServiceProvider = internalServiceProvider;
+            this.externalServiceProvider = externalServiceProvider;
         }
 
         /// <summary> Constructor </summary>
         /// <param name="siloName">Name of this silo.</param>
         /// <param name="configFile">Silo config file that will be used to initialize this silo.</param>
-        public SiloHost(string siloName, FileInfo configFile)
+        public SiloHost(string siloName, FileInfo configFile, 
+            IServiceProvider internalServiceProvider = null, IServiceProvider externalServiceProvider = null,
+            bool useCustomServiceProvider = false)
             : this(siloName)
         {
             ConfigFileName = configFile.FullName;
             var config = new ClusterConfiguration();
             config.LoadFromFile(ConfigFileName);
+            this.internalServiceProvider = internalServiceProvider;
+            this.externalServiceProvider = externalServiceProvider;
             SetSiloConfig(config);
         }
 

--- a/src/OrleansRuntime/Silo/SiloHost.cs
+++ b/src/OrleansRuntime/Silo/SiloHost.cs
@@ -95,6 +95,7 @@ namespace Orleans.Runtime.Host
             IsStarted = false;
             this.internalServiceProvider = internalServiceProvider;
             this.externalServiceProvider = externalServiceProvider;
+            this.useCustomServiceProvider = useCustomServiceProvider;
         }
 
         /// <summary> Constructor </summary>
@@ -108,6 +109,7 @@ namespace Orleans.Runtime.Host
             SetSiloConfig(config);
             this.internalServiceProvider = internalServiceProvider;
             this.externalServiceProvider = externalServiceProvider;
+            this.useCustomServiceProvider = useCustomServiceProvider;
         }
 
         /// <summary> Constructor </summary>
@@ -123,6 +125,7 @@ namespace Orleans.Runtime.Host
             config.LoadFromFile(ConfigFileName);
             this.internalServiceProvider = internalServiceProvider;
             this.externalServiceProvider = externalServiceProvider;
+            this.useCustomServiceProvider = useCustomServiceProvider;
             SetSiloConfig(config);
         }
 
@@ -138,7 +141,7 @@ namespace Orleans.Runtime.Host
             try
             {
                 if (!ConfigLoaded) LoadOrleansConfig();
-                orleans = new Silo(Name, Type, Config);
+                orleans = new Silo(Name, Type, Config, internalServiceProvider, externalServiceProvider, useCustomServiceProvider);
                 logger.Info(ErrorCode.Runtime_Error_100288, "Successfully initialized Orleans silo '{0}' as a {1} node.", orleans.Name, orleans.Type);
             }
             catch (Exception exc)

--- a/src/OrleansRuntime/Silo/SiloHostBuilder.cs
+++ b/src/OrleansRuntime/Silo/SiloHostBuilder.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Host;
+
+namespace Orleans.Runtime.Startup
+{
+    public class SiloHostBuilder : ISiloHostBuilder
+    {
+        private Microsoft.Extensions.Logging.ILoggerFactory loggerFactory;
+        private List<Action<IServiceCollection>> externalServiceConfigDelegates;
+        private ClusterConfiguration clusterConfiguration;
+        private string startUpType;
+        public SiloHostBuilder()
+        {
+        }
+
+        public ISiloHostBuilder UseStartup<TStartUp>()
+        {
+            this.startUpType = typeof(TStartUp).AssemblyQualifiedName;
+            return this;
+        }
+
+        public ISiloHostBuilder ConfigureLogging(System.Action<Microsoft.Extensions.Logging.ILoggerFactory> loggerFactoryDelegate)
+        {
+            if (loggerFactoryDelegate == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactoryDelegate));
+            }
+            loggerFactoryDelegate(loggerFactory);
+            return this;
+        }
+
+        public ISiloHostBuilder ConfigureServices(
+            System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> configServiceDelegate)
+        {
+            if (configServiceDelegate == null)
+            {
+                throw new ArgumentNullException(nameof(configServiceDelegate));
+            }
+            externalServiceConfigDelegates.Add(configServiceDelegate);
+            return this;
+        }
+
+        public ISiloHostBuilder UseLoggerFactory(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory)
+        {
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+            this.loggerFactory = loggerFactory;
+            return this;
+        }
+
+        public ISiloHostBuilder UseClusterConfiguration(ClusterConfiguration clusterConfiguration)
+        {
+            this.clusterConfiguration = clusterConfiguration;
+            return this;
+        }
+
+        public SiloHost Build(string siloName)
+        {
+            // concept of internal and external service provider. 
+            // internal service provider only register system types, and use our own specified DI container, only used by other system types
+            // external service provider can use whatever DI container user want and it can contain system types which can be used for external
+            // external service provider mainly used in GrainCreator to create Grain with DI, or can potentially used in creating providers
+            IServiceProvider internalServiceProvider = StartupBuilder.RegisterAllSystemTypes(new ServiceCollection()).BuildServiceProvider();
+            IServiceProvider externalServiceProvider = null;
+            bool useCustomServiceProvider;
+            if (externalServiceConfigDelegates.Any())
+            {
+                IServiceCollection externalCollection = null;
+                foreach (var configServiceDelegate in externalServiceConfigDelegates)
+                {
+                    configServiceDelegate(externalCollection);
+                }
+                StartupBuilder.RegisterSystemTypesWhichCanbeUsedByExternal(internalServiceProvider, externalCollection);
+                externalServiceProvider = externalCollection.BuildServiceProvider();
+                useCustomServiceProvider = true;
+            }else if (this.startUpType != null)
+            {
+                externalServiceProvider = StartupBuilder.ConfigureStartup(this.startUpType, internalServiceProvider, out useCustomServiceProvider);
+            }
+            else
+            {
+                // if user didn't inject any services into DI
+                IServiceCollection externalCollection = new ServiceCollection();
+                StartupBuilder.RegisterSystemTypesWhichCanbeUsedByExternal(internalServiceProvider, externalCollection);
+                useCustomServiceProvider = false;
+                externalServiceProvider = externalCollection.BuildServiceProvider();
+            }
+
+            return new SiloHost(siloName, clusterConfiguration, internalServiceProvider, externalServiceProvider);
+        }
+    }
+}

--- a/src/OrleansRuntime/Silo/SiloHostBuilder.cs
+++ b/src/OrleansRuntime/Silo/SiloHostBuilder.cs
@@ -71,7 +71,7 @@ namespace Orleans.Runtime.Startup
             IServiceProvider internalServiceProvider = StartupBuilder.RegisterAllSystemTypes(new ServiceCollection()).BuildServiceProvider();
             IServiceProvider externalServiceProvider = null;
             bool useCustomServiceProvider;
-            if (externalServiceConfigDelegates.Any())
+            if (externalServiceConfigDelegates != null)
             {
                 IServiceCollection externalCollection = null;
                 foreach (var configServiceDelegate in externalServiceConfigDelegates)
@@ -94,7 +94,8 @@ namespace Orleans.Runtime.Startup
                 externalServiceProvider = externalCollection.BuildServiceProvider();
             }
 
-            return new SiloHost(siloName, clusterConfiguration, internalServiceProvider, externalServiceProvider);
+            return new SiloHost(siloName, clusterConfiguration, internalServiceProvider, 
+                externalServiceProvider, useCustomServiceProvider);
         }
     }
 }

--- a/src/OrleansRuntime/Startup/StartupBuilder.cs
+++ b/src/OrleansRuntime/Startup/StartupBuilder.cs
@@ -84,6 +84,7 @@ namespace Orleans.Runtime.Startup
             // Note: you can replace IGrainFactory with your own implementation, but 
             // we don't recommend it, in the aspect of performance and usability
             serviceCollection.AddSingleton<GrainFactory>((_sp) => new GrainFactory());
+            serviceCollection.AddSingleton<IGrainFactory>((sp) => (sp.GetService<GrainFactory>()));
             return serviceCollection;
         }
 

--- a/src/OrleansRuntime/Startup/StartupBuilder.cs
+++ b/src/OrleansRuntime/Startup/StartupBuilder.cs
@@ -12,6 +12,39 @@ namespace Orleans.Runtime.Startup
     /// </summary>
     internal class StartupBuilder
     {
+        internal static IServiceProvider ConfigureStartup(string startupTypeName, IServiceProvider internalServiceProvider,out bool usingCustomServiceProvider)
+        {
+            usingCustomServiceProvider = false;
+            IServiceCollection serviceCollection = new ServiceCollection();
+            ConfigureServicesBuilder servicesMethod = null;
+            Type startupType = null;
+
+            if (!String.IsNullOrWhiteSpace(startupTypeName))
+            {
+                startupType = Type.GetType(startupTypeName);
+                if (startupType == null)
+                {
+                    throw new InvalidOperationException($"Can not locate the type specified in the configuration file: '{startupTypeName}'.");
+                }
+
+                servicesMethod = FindConfigureServicesDelegate(startupType);
+                if (servicesMethod != null && !servicesMethod.MethodInfo.IsStatic)
+                {
+                    usingCustomServiceProvider = true;
+                }
+            }
+
+            RegisterSystemTypesWhichCanbeUsedByExternal(internalServiceProvider, serviceCollection);
+
+            if (usingCustomServiceProvider)
+            {
+                var instance = Activator.CreateInstance(startupType);
+                return servicesMethod.Build(instance, serviceCollection);
+            }
+
+            return serviceCollection.BuildServiceProvider();
+        }
+
         internal static IServiceProvider ConfigureStartup(string startupTypeName, out bool usingCustomServiceProvider)
         {
             usingCustomServiceProvider = false;
@@ -34,7 +67,7 @@ namespace Orleans.Runtime.Startup
                 }
             }
 
-            RegisterSystemTypes(serviceCollection);
+            RegisterAllSystemTypes(serviceCollection);
 
             if (usingCustomServiceProvider)
             {
@@ -45,13 +78,18 @@ namespace Orleans.Runtime.Startup
             return serviceCollection.BuildServiceProvider();
         }
 
-        private static void RegisterSystemTypes(IServiceCollection serviceCollection)
+        public static IServiceCollection RegisterAllSystemTypes(IServiceCollection serviceCollection)
         {
             // add system types
             // Note: you can replace IGrainFactory with your own implementation, but 
             // we don't recommend it, in the aspect of performance and usability
             serviceCollection.AddSingleton<GrainFactory>((_sp) => new GrainFactory());
-            serviceCollection.AddSingleton<IGrainFactory>((sp) => sp.GetService<GrainFactory>());
+            return serviceCollection;
+        }
+
+        public static void RegisterSystemTypesWhichCanbeUsedByExternal(IServiceProvider internalSeviceProvider, IServiceCollection externalserviceCollection)
+        {
+            externalserviceCollection.AddSingleton<IGrainFactory>(internalSeviceProvider.GetService<GrainFactory>());
         }
 
         private static ConfigureServicesBuilder FindConfigureServicesDelegate(Type startupType)

--- a/src/OrleansRuntime/project.json
+++ b/src/OrleansRuntime/project.json
@@ -1,6 +1,7 @@
-{
+﻿{
   "dependencies": {
-    "Microsoft.Extensions.DependencyInjection": "1.0.0"
+    "Microsoft.Extensions.DependencyInjection": "1.0.0",
+    "Microsoft.Extensions.Logging": "1.0.0"
   },
   "frameworks": {
     "net451": {}

--- a/test/Tester/DependencyInjectionGrainTestsWithSiloHostBuilder.cs
+++ b/test/Tester/DependencyInjectionGrainTestsWithSiloHostBuilder.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Host;
+using Orleans.Runtime.Startup;
+using Orleans.TestingHost;
+using Tester;
+using UnitTests.GrainInterfaces;
+using UnitTests.Grains;
+using UnitTests.Tester;
+using Xunit;
+
+namespace UnitTests.General
+{
+    [TestCategory("DI")]
+    public class DependencyInjectionGrainTestsWithSiloHostBuilder
+    {
+
+        [Fact, TestCategory("BVT"), TestCategory("Functional")]
+        public async Task CanGetGrainWithSIngletonInjectedDependencies()
+        {
+            AppDomain appDomain =  AppDomain.CreateDomain("OrleansHost", null, GetAppDomainSetupInfo());
+
+            var config = ClientConfiguration.LocalhostSilo();
+            GrainClient.Initialize(config);
+
+            var grain1 = GrainClient.GrainFactory.GetGrain<IDIGrainWithInjectedServices>(0);
+            var grain2 = GrainClient.GrainFactory.GetGrain<IDIGrainWithInjectedServices>(1);
+            // the injected service will return the same value only if it's the same instance
+            Assert.Equal(
+                await grain1.GetStringValue(),
+                await grain2.GetStringValue());
+        }
+
+        private static AppDomainSetup GetAppDomainSetupInfo()
+        {
+            var currentAppDomain = AppDomain.CurrentDomain;
+
+            return new AppDomainSetup
+            {
+                ApplicationBase = Environment.CurrentDirectory,
+                ConfigurationFile = currentAppDomain.SetupInformation.ConfigurationFile,
+                ShadowCopyFiles = currentAppDomain.SetupInformation.ShadowCopyFiles,
+                ShadowCopyDirectories = currentAppDomain.SetupInformation.ShadowCopyDirectories,
+                CachePath = currentAppDomain.SetupInformation.CachePath,
+                AppDomainInitializer = InitSilo,
+            };
+        }
+
+        public static void InitSilo(string[] args)
+        {
+            siloHost = new SiloHostBuilder()
+                .UseClusterConfiguration(ClusterConfiguration.LocalhostPrimarySilo())
+                .UseStartup<TestStartup>()
+                .Build("TestSilo");
+            siloHost.InitializeOrleansSilo();
+            siloHost.StartOrleansSilo();
+        }
+
+        private static SiloHost siloHost;
+       
+        public class TestStartup
+        {
+            public IServiceProvider ConfigureServices(IServiceCollection services)
+            {
+                services.AddSingleton<IInjectedService, InjectedService>();
+                return services.BuildServiceProvider();
+            }
+        }
+    }
+}

--- a/test/Tester/Tester.csproj
+++ b/test/Tester/Tester.csproj
@@ -50,6 +50,7 @@
   <ItemGroup>
     <Compile Include="CancellationTests\GrainCancellationTokenTests.cs" />
     <Compile Include="CollectionFixtures.cs" />
+    <Compile Include="DependencyInjectionGrainTestsWithSiloHostBuilder.cs" />
     <Compile Include="MethodInterceptionTests.cs" />
     <Compile Include="BaseClusterFixture.cs" />
     <Compile Include="General\JsonGrainTests.cs" />


### PR DESCRIPTION
SiloHostBuider pattern 
with idea of an internal service provider and an external service provider

concept of internal and external service provider. 
1.  internal service provider only register system types, and use our own specified DI container, only used by other system types
2.  external service provider can use whatever DI container user want and it can contain system types which can be used for external
3.  external service provider mainly used in GrainCreator to create Grain with DI, or can potentially used in creating providers
4. This can solve problem like `IStreamProviderManager` which intended for just internal use,  can be injected to system types by internal service provider, while not accessible for external DI use. 
